### PR TITLE
Changed GCM endpoint to FCM endpoint

### DIFF
--- a/lib/higcm/sender.rb
+++ b/lib/higcm/sender.rb
@@ -63,7 +63,7 @@ module HiGCM
         end
 
         request = Typhoeus::Request.new(
-          'https://android.googleapis.com/gcm/send',
+          'https://fcm.googleapis.com/fcm/send',
           :headers         => headers,
           :method          => :post,
           :body            => body.to_json,

--- a/spec/lib/higcm/handler_spec.rb
+++ b/spec/lib/higcm/handler_spec.rb
@@ -28,7 +28,7 @@ describe HiGCM::Handler do
       @api_key     = 'foo'
       sender       = HiGCM::Sender.new(@api_key)
       sender.hydra = Typhoeus::Hydra.hydra
-      sender.hydra.stub(:post, 'https://android.googleapis.com/gcm/send').and_return(@stub_gcm_response)
+      sender.hydra.stub(:post, 'https://fcm.googleapis.com/fcm/send').and_return(@stub_gcm_response)
 
       _fails   = 0
       _success = 0

--- a/spec/lib/higcm/sender_spec.rb
+++ b/spec/lib/higcm/sender_spec.rb
@@ -15,7 +15,7 @@ describe HiGCM::Sender do
     )
     @sender = HiGCM::Sender.new(@api_key)
     @sender.hydra = Typhoeus::Hydra.new
-    @sender.hydra.stub(:post, 'https://android.googleapis.com/gcm/send').and_return(@stub_gcm_response)
+    @sender.hydra.stub(:post, 'https://fcm.googleapis.com/fcm/send').and_return(@stub_gcm_response)
   end
 
   describe "#initialize" do


### PR DESCRIPTION
 * android.googleapis.com/gcm/send -> fcm.googleapis.com/fcm/send
 * https://developers.google.com/cloud-messaging/android/android-migrate-fcm

Actually the error message from FCM is `DeprecatedEndpoint` and it seems Google  deprecated GCM server these days. (Similar issue I found from PushSharp: https://github.com/Redth/PushSharp/issues/907 . This issue was reported yesterday)

